### PR TITLE
Potential fix for code scanning alert no. 2: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -7,9 +7,14 @@ on:
   release:
     types: [created]
 
+permissions:
+  contents: read
+
 jobs:
   build:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4
@@ -21,6 +26,9 @@ jobs:
   publish-npm:
     needs: build
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4


### PR DESCRIPTION
Potential fix for [https://github.com/leandro3810/vite-project/security/code-scanning/2](https://github.com/leandro3810/vite-project/security/code-scanning/2)

To fix the issue, we need to add a `permissions` block to the workflow. This block should specify the minimal permissions required for each job. For the `build` job, only `contents: read` is needed to run tests. For the `publish-npm` job, `contents: read` and `packages: write` are required to publish the package to npm. These permissions ensure that the workflow has only the access it needs to perform its tasks.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._

## Summary by Sourcery

Add minimal permissions to GitHub workflow to address code scanning security alert

Bug Fixes:
- Fixed code scanning security alert by defining explicit job permissions

CI:
- Added permissions block to workflow to specify minimal required access for jobs